### PR TITLE
sinatra-content-for is unavailable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source :rubygems
 
 # Framework
 gem 'sinatra'
-gem 'sinatra-content-for'
+gem 'sinatra-contrib'
 
 # HTML rendring engine Haml
 gem 'haml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,12 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    backports (3.3.0)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
     coffee-script-source (1.2.0)
+    eventmachine (1.0.3)
     execjs (1.3.0)
       multi_json (~> 1.0)
     haml (3.1.4)
@@ -14,13 +16,20 @@ GEM
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
     sass (3.1.12)
     sinatra (1.3.2)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
-    sinatra-content-for (0.2)
-      sinatra
+    sinatra-contrib (1.3.2)
+      backports (>= 2.0)
+      eventmachine
+      rack-protection
+      rack-test
+      sinatra (~> 1.3.0)
+      tilt (~> 1.3)
     sprockets (2.3.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -39,6 +48,6 @@ DEPENDENCIES
   haml
   sass
   sinatra
-  sinatra-content-for
+  sinatra-contrib
   sprockets
   therubyracer


### PR DESCRIPTION
sinatra-content-for is unavailable in rubygems and it include sinatra-contrib gem. 
